### PR TITLE
feat: refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 dist/
 vendor/
+bin/
+coverage.out

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,4 +14,9 @@ archive:
   name_template: '{{ .Binary }}_{{ .Os }}_{{ .Arch }}'
 dockers:
   - image: caarlos0/version_exporter
-    latest: true
+    extra_files:
+    - config.yaml
+    tag_templates:
+    - latest
+    - "{{ .Tag }}"
+    - "v{{ .Major }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM gcr.io/distroless/base
 EXPOSE 9333
 COPY version_exporter /
+COPY config.yaml /
 ENTRYPOINT ["/version_exporter"]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,7 +10,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/alecthomas/template"
-  packages = [".","parse"]
+  packages = [
+    ".",
+    "parse"
+  ]
   revision = "a0175ee3bccc567396460bf5acd36800cb10c49c"
 
 [[projects]]
@@ -32,10 +35,22 @@
   revision = "130e6b02ab059e7b717a096f397c5b60111cae74"
 
 [[projects]]
+  name = "github.com/google/go-github"
+  packages = ["github"]
+  revision = "e48060a28fac52d0f1cb758bc8b87c07bac4a87d"
+  version = "v15.0.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/google/go-querystring"
+  packages = ["query"]
+  revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
+
+[[projects]]
   name = "github.com/masterminds/semver"
   packages = ["."]
-  revision = "517734cc7d6470c0d07130e40fd40bdeb9bcd3fd"
-  version = "v1.3.1"
+  revision = "c7af12943936e8c39859482e61f0574c2fd7fc75"
+  version = "v1.4.2"
 
 [[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
@@ -51,7 +66,10 @@
 
 [[projects]]
   name = "github.com/prometheus/client_golang"
-  packages = ["prometheus","prometheus/promhttp"]
+  packages = [
+    "prometheus",
+    "prometheus/promhttp"
+  ]
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
@@ -64,13 +82,21 @@
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","log","model"]
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "log",
+    "model"
+  ]
   revision = "2f17f4a9d485bf34b4bfaccc273805040e4f86c8"
 
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/procfs"
-  packages = [".","xfs"]
+  packages = [
+    ".",
+    "xfs"
+  ]
   revision = "e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2"
 
 [[projects]]
@@ -87,9 +113,46 @@
 
 [[projects]]
   branch = "master"
+  name = "golang.org/x/net"
+  packages = [
+    "context",
+    "context/ctxhttp"
+  ]
+  revision = "1e491301e022f8f977054da4c2d852decd59571f"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "internal"
+  ]
+  revision = "1e0a3fa8ba9a5c9eb35c271780101fdaf1b205d7"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows","windows/registry","windows/svc/eventlog"]
+  packages = [
+    "unix",
+    "windows",
+    "windows/registry",
+    "windows/svc/eventlog"
+  ]
   revision = "314a259e304ff91bd6985da2a7149bbf91237993"
+
+[[projects]]
+  name = "google.golang.org/appengine"
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
+  revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
+  version = "v1.0.0"
 
 [[projects]]
   name = "gopkg.in/alecthomas/kingpin.v2"
@@ -97,9 +160,15 @@
   revision = "1087e65c9441605df944fb12c33f0fe7072d18ca"
   version = "v2.2.5"
 
+[[projects]]
+  branch = "v1"
+  name = "gopkg.in/yaml.v1"
+  packages = ["."]
+  revision = "9f9df34309c04878acc86042b16630b0f696e1de"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ea6aa2fac1dd98836e61f960dfcc269c95baeb568c47b854bfa86f3f7a843850"
+  inputs-digest = "a650ff7a736251f4f45a44a45a446739e12753f180510be85e98405fd46d9134"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,8 +4,8 @@
 [[projects]]
   name = "github.com/alecthomas/kingpin"
   packages = ["."]
-  revision = "1087e65c9441605df944fb12c33f0fe7072d18ca"
-  version = "v2.2.5"
+  revision = "947dcec5ba9c011838740e680966fd7087a71d0d"
+  version = "v2.2.6"
 
 [[projects]]
   branch = "master"
@@ -26,13 +26,13 @@
   branch = "master"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
-  revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  revision = "130e6b02ab059e7b717a096f397c5b60111cae74"
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/google/go-github"
@@ -55,8 +55,8 @@
 [[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
-  revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
-  version = "v1.0.0"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -77,7 +77,7 @@
   branch = "master"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
-  revision = "6f3806018612930941127f2a7c6c453ba2c527d2"
+  revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
@@ -88,28 +88,30 @@
     "log",
     "model"
   ]
-  revision = "2f17f4a9d485bf34b4bfaccc273805040e4f86c8"
+  revision = "7600349dcfe1abd18d72d3a1770870d9800a7801"
 
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
+    "internal/util",
+    "nfs",
     "xfs"
   ]
-  revision = "e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2"
+  revision = "94663424ae5ae9856b40a9f170762b4197024661"
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
-  version = "v1.0.3"
+  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
+  version = "v1.0.5"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "9419663f5a44be8b34ca85f08abc5fe1be11f8a3"
+  revision = "b47b1587369238182299fe4dad77d05b8b461e06"
 
 [[projects]]
   branch = "master"
@@ -138,7 +140,7 @@
     "windows/registry",
     "windows/svc/eventlog"
   ]
-  revision = "314a259e304ff91bd6985da2a7149bbf91237993"
+  revision = "9527bec2660bd847c050fda93a0f0c6dee0800bb"
 
 [[projects]]
   name = "google.golang.org/appengine"
@@ -157,18 +159,18 @@
 [[projects]]
   name = "gopkg.in/alecthomas/kingpin.v2"
   packages = ["."]
-  revision = "1087e65c9441605df944fb12c33f0fe7072d18ca"
-  version = "v2.2.5"
+  revision = "947dcec5ba9c011838740e680966fd7087a71d0d"
+  version = "v2.2.6"
 
 [[projects]]
-  branch = "v1"
-  name = "gopkg.in/yaml.v1"
+  name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "9f9df34309c04878acc86042b16630b0f696e1de"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a650ff7a736251f4f45a44a45a446739e12753f180510be85e98405fd46d9134"
+  inputs-digest = "ce3660bd0d7c6d55424d8d2c3bb4b0a182c11513f55ffed529dac34ae1d7ff08"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 SOURCE_FILES?=./...
 TEST_PATTERN?=.
 TEST_OPTIONS?=
+OS=$(shell uname -s)
+
+export PATH := ./bin:$(PATH)
 
 setup:
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh

--- a/README.md
+++ b/README.md
@@ -5,13 +5,31 @@ Exports the expiration time of your domains as prometheus metrics.
 ## Running
 
 ```console
-./version_exporter -b ":9333"
+./version_exporter --bind ":9333"
 ```
 
 Or with docker:
 
 ```console
-docker run -p 9333:9333 caarlos0/version_exporter
+docker run -p 127.0.0.1:9333:9333 -v config.yaml:/config.yaml:ro caarlos0/version_exporter
+```
+
+Or with docker-compose:
+
+```yaml
+version: '3'
+services:
+  releases:
+    image: caarlos0/gversion_exporter:v1
+    restart: always
+    volumes:
+    - /path/to/config.yml:/etc/config.yml:ro
+    command:
+    - '--config.file=/etc/config.yml'
+    ports:
+    - 127.0.0.1:9333:9333
+    env_file:
+    - .env
 ```
 
 ## Configuration
@@ -21,24 +39,8 @@ On the prometheus settings, add the domain_expoter prober:
 ```yaml
 scrape_configs:
   - job_name: version
-    scrape_interval: 1m
-    metrics_path: /probe
-    relabel_configs:
-      - source_labels: [__address__]
-        target_label: __param_repo
-        regex: ^(.*)\?tag=.*$
-      - source_labels: [__address__]
-        target_label: __param_tag
-        regex: ^.*?tag=(.*)$
-      - source_labels: [__param_repo]
-        target_label: repo
-      - target_label: __address__
-        replacement: localhost:9333 # version_exporter address
     static_configs:
-      - targets:
-        - prometheus/prometheus?tag=v1.7.1
-        - goreleaser/goreleaser?tag=v0.34.0
-        - caarlos0/version_exporter?tag=v0.0.1
+      - targets: [ 'version_exporter:9222' ]
 ```
 
 It works more or less like prometheus's

--- a/README.md
+++ b/README.md
@@ -55,20 +55,18 @@ scrape_configs:
 
 Alerting rules example:
 
-> TODO: update this
-
-```rules
-ALERT OutdatedSoftware
-  IF up_to_date == 0
-  FOR 30m
-  LABELS {
-    severity = "WARNING",
-  }
-  ANNOTATIONS {
-    description = "we are running the version {{ $labels.current }} of {{ $labels.repo }}, but version {{ $labels.latest }} is available",
-    summary = "{{ $labels.repo }}: new version available",
-  }
-
+```yaml
+groups:
+- name: versions
+  rules:
+  - alert: SoftwareOutOfDate
+    expr: version_up_to_date == 0
+    for: 1s
+    labels:
+      severity: warning
+    annotations:
+      summary: "{{$labels.repository}}: out of date"
+      description: "latest version {{ $labels.latest }} is not within constraint {{ $labels.constraint }}"
 ```
 
 ## Building locally

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Exports the expiration time of your domains as prometheus metrics.
 ## Running
 
 ```console
-./version_exporter --bind ":9333"
+version_exporter --bind ":9333"
 ```
 
 Or with docker:
@@ -32,21 +32,30 @@ services:
     - .env
 ```
 
-## Configuration
+You can personalize the `config.yaml` file like following:
 
-On the prometheus settings, add the domain_expoter prober:
+```yaml
+repositories:
+  # repository: semver constraint (check https://github.com/masterminds/semver#working-with-pre-release-versions)
+  prometheus/alertmanager: ~v0.14.0
+  prometheus/prometheus: ^2.1.0
+  caarlos0/version_exporter: 0.0.5
+```
+
+> You can reload the config file by sending a `SIGHUP` to version_exporter process.
+
+On the prometheus settings, add the version_exporter job:
 
 ```yaml
 scrape_configs:
   - job_name: version
     static_configs:
-      - targets: [ 'version_exporter:9222' ]
+      - targets: [ 'version_exporter:9333' ]
 ```
 
-It works more or less like prometheus's
-[blackbox_exporter](https://github.com/prometheus/blackbox_exporter).
-
 Alerting rules example:
+
+> TODO: update this
 
 ```rules
 ALERT OutdatedSoftware

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,3 @@
+repositories:
+  prometheus/prometheus: ^2.1.0
+  caarlos0/version_exporter: 0.0.5

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/log"
 	"golang.org/x/oauth2"
-	yaml "gopkg.in/yaml.v1"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const ns = "version"
@@ -50,10 +50,10 @@ type Config struct {
 }
 
 func main() {
-	kingpin.Version("version_releases_exporter version " + version)
+	kingpin.Version("version_exporter version " + version)
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
-	log.Info("starting version_releases_exporter", version)
+	log.Info("starting version_exporter", version)
 
 	if *debug {
 		_ = log.Base().SetLevel("debug")

--- a/main.go
+++ b/main.go
@@ -1,41 +1,90 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/alecthomas/kingpin"
+	"github.com/google/go-github/github"
 	"github.com/masterminds/semver"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/log"
+	"golang.org/x/oauth2"
+	yaml "gopkg.in/yaml.v1"
 )
+
+const ns = "version"
 
 var (
-	bind    = kingpin.Flag("bind", "addr to bind the server").Default(":9333").String()
-	debug   = kingpin.Flag("debug", "show debug logs").Default("false").Bool()
+	bind       = kingpin.Flag("bind", "addr to bind the server").Default(":9333").String()
+	debug      = kingpin.Flag("debug", "show debug logs").Default("false").Bool()
+	token      = kingpin.Flag("github.token", "github token").Envar("GITHUB_TOKEN").String()
+	configFile = kingpin.Flag("config.file", "config file").Default("config.yaml").ExistingFile()
+	interval   = kingpin.Flag("refresh.interval", "time between refreshes with github api").Default("15m").Duration()
+
 	version = "dev"
-	token   = os.Getenv("GITHUB_TOKEN")
+
+	scrapeDuration = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: prometheus.BuildFQName(ns, "", "scrape_duration_seconds"),
+		Help: "Returns how long the probe took to complete in seconds",
+	})
+	upToDate = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: prometheus.BuildFQName(ns, "", "up_to_date"),
+		Help: "Wether the repository latest version is in the specified semver range",
+	},
+		[]string{"repository", "constraint", "latest"},
+	)
 )
 
+type Config struct {
+	Repositories map[string]string `yaml:"repositories"`
+}
+
 func main() {
-	kingpin.Version("version_exporter version " + version)
+	kingpin.Version("version_releases_exporter version " + version)
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
+	log.Info("starting version_releases_exporter", version)
 
 	if *debug {
 		_ = log.Base().SetLevel("debug")
 		log.Debug("enabled debug mode")
 	}
 
-	log.Info("starting version_exporter ", version)
+	var config Config
+	loadConfig(&config)
+	var configCh = make(chan os.Signal, 1)
+	signal.Notify(configCh, syscall.SIGHUP)
+	go func() {
+		for range configCh {
+			log.Info("reloading config...")
+			loadConfig(&config)
+		}
+	}()
 
+	var ctx = context.Background()
+	var client = github.NewClient(nil)
+	if *token != "" {
+		client = github.NewClient(oauth2.NewClient(
+			ctx,
+			oauth2.StaticTokenSource(&oauth2.Token{AccessToken: *token}),
+		))
+	}
+
+	go keepCollecting(ctx, client, &config)
+	prometheus.MustRegister(scrapeDuration)
+	prometheus.MustRegister(upToDate)
 	http.Handle("/metrics", promhttp.Handler())
-	http.HandleFunc("/probe", probeHandler)
+
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(
 			w, `
@@ -44,7 +93,6 @@ func main() {
 			<body>
 				<h1>Version Exporter</h1>
 				<p><a href="/metrics">Metrics</a></p>
-				<p><a href="/probe?repo=prometheus/prometheus&tag=v2.2.1">probe prometheus/prometheus</a></p>
 			</body>
 			</html>
 			`,
@@ -56,6 +104,27 @@ func main() {
 	}
 }
 
+func keepCollecting(ctx context.Context, client *github.Client, config *Config) {
+	for {
+		if err := collectOnce(ctx, client, config); err != nil {
+			log.Error("failed to collect:", err)
+		}
+		time.Sleep(*interval)
+	}
+}
+
+func loadConfig(config *Config) {
+	bts, err := ioutil.ReadFile(*configFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var newConfig Config
+	if err := yaml.Unmarshal(bts, &newConfig); err != nil {
+		log.Fatal(err)
+	}
+	*config = newConfig
+}
+
 // Release from github api
 type Release struct {
 	TagName     string    `json:"tag_name,omitempty"`
@@ -64,49 +133,31 @@ type Release struct {
 	PublishedAt time.Time `json:"published_at,omitempty"`
 }
 
-func probeHandler(w http.ResponseWriter, r *http.Request) {
-	var params = r.URL.Query()
-	var repo = params.Get("repo")
-	var tag = params.Get("tag")
+func collectOnce(ctx context.Context, client *github.Client, config *Config) error {
 	var start = time.Now()
-	var log = log.With("repo", repo)
-	var updateGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "up_to_date",
-		Help: "will be 0 if there is a new version available",
-	})
-	var probeDurationGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "probe_duration_seconds",
-		Help: "Returns how long the probe took to complete in seconds",
-	})
-	var registry = prometheus.NewRegistry()
-	registry.MustRegister(updateGauge)
-	registry.MustRegister(probeDurationGauge)
-	if repo == "" {
-		http.Error(w, "repo parameter is missing", http.StatusBadRequest)
-		return
+	for repo, c := range config.Repositories {
+		var log = log.With("repo", repo)
+		log.Info("collecting")
+		constraint, err := semver.NewConstraint(c)
+		if err != nil {
+			return err
+		}
+		version, err := findLatest(repo)
+		if err != nil {
+			return err
+		}
+		if version != nil {
+			var up = constraint.Check(version)
+			log.With("constraint", constraint).
+				With("latest", version).
+				With("up_to_date", up).
+				Debug("checked")
+			upToDate.WithLabelValues(repo, c, version.String()).
+				Set(boolToFloat(up))
+		}
 	}
-	if tag == "" {
-		http.Error(w, "tag parameter is missing", http.StatusBadRequest)
-		return
-	}
-	currentVersion, err := semver.NewVersion(tag)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	version, err := findLatest(repo)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	if version != nil {
-		log.With("current", currentVersion).With("latest", version).
-			With("up_to_date", version.Equal(currentVersion)).
-			Debug("checked")
-		updateGauge.Set(boolToFloat(!version.GreaterThan(currentVersion)))
-	}
-	probeDurationGauge.Set(time.Since(start).Seconds())
-	promhttp.HandlerFor(registry, promhttp.HandlerOpts{}).ServeHTTP(w, r)
+	scrapeDuration.Set(time.Since(start).Seconds())
+	return nil
 }
 
 func boolToFloat(b bool) float64 {
@@ -146,8 +197,8 @@ func findReleases(repo string) ([]Release, error) {
 		fmt.Sprintf("https://api.github.com/repos/%s/releases", repo),
 		nil,
 	)
-	if token != "" {
-		req.Header.Add("Authorization", fmt.Sprintf("token %s", token))
+	if *token != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("token %s", *token))
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
let's do this better:

- a config file with all projects listed
- the version support constraints, not just exact versions
- `SIGHUP` to reload the file
- check the github API periodically
  - the exporter controls that instead of prometheus

TODO:

- [ ] unit tests
- [ ] organize the pkg better